### PR TITLE
Bypass should be set for operators instead everyone but operators

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,4 +5,4 @@ api-version: '1.21'
 permissions:
   forcexaerofairplay.bypass:
     description: Prevents the plugin from changing your minimap mode.
-    default: not op
+    default: op


### PR DESCRIPTION
Fix: Operators should be able to bypass the fair mode. Currently everyone but operators are excluded by default.

This should fix #2 